### PR TITLE
Show login dialog on all worldcup pages when user is not signed in

### DIFF
--- a/worldcup/index.html
+++ b/worldcup/index.html
@@ -1706,6 +1706,8 @@ async function tryRestoreSession() {
             updateUserUI();
             await loadPredictions();
             await loadLeagues();
+        } else {
+            openSignInModal();
         }
     } catch (_) {}
 }

--- a/worldcup/match.html
+++ b/worldcup/match.html
@@ -259,6 +259,7 @@
 
 <script type="module">
 import { TEAM_DATA } from './team-data.js';
+import { openSignInModal, closeSignInModal } from './signin-modal.js';
 
 const API = '/world_cup';
 const params = new URLSearchParams(location.search);
@@ -714,6 +715,15 @@ if (!matchId) {
     document.getElementById('panel-overview').innerHTML = '<div class="empty">No match specified.</div>';
 } else {
     await Promise.all([tryRestoreSession(), loadMatch()]);
+    if (!state.user) openSignInModal();
+    document.addEventListener('wc:signin', e => {
+        state.user = e.detail;
+        renderMeetups();
+        const inputRow = document.getElementById('chat-input-row');
+        const authGate = document.getElementById('chat-auth-gate');
+        if (inputRow) inputRow.style.display = 'flex';
+        if (authGate) authGate.style.display = 'none';
+    });
     initUserLocation();
     loadMeetups();
 }

--- a/worldcup/meetup.html
+++ b/worldcup/meetup.html
@@ -174,35 +174,6 @@
             white-space: nowrap; -webkit-tap-highlight-color: transparent; flex-shrink: 0; }
         #signin-bar-btn:active { background: var(--primary-light); }
 
-        /* ── BOTTOM SHEET SIGN-IN ── */
-        #sheet-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 400;
-            display: none; align-items: flex-end; }
-        #sheet-overlay.open { display: flex; }
-        #signin-sheet { background: white; width: 100%; border-radius: 22px 22px 0 0;
-            padding: 0 20px 32px; max-width: 540px; margin: 0 auto;
-            transform: translateY(100%); transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1); }
-        #sheet-overlay.open #signin-sheet { transform: translateY(0); }
-        .sheet-handle { width: 40px; height: 4px; background: var(--border); border-radius: 2px; margin: 12px auto 20px; }
-        .sheet-icon { font-size: 2.2rem; text-align: center; margin-bottom: 8px; }
-        .sheet-title { font-size: 1.2rem; font-weight: 900; color: var(--primary); text-align: center; margin-bottom: 4px; }
-        .sheet-sub { font-size: 0.82rem; color: var(--muted); text-align: center; margin-bottom: 22px; line-height: 1.4; }
-        .sheet-field { width: 100%; padding: 15px 16px; border: 2px solid var(--border); border-radius: 12px;
-            font-size: 1rem; outline: none; font-family: inherit; color: var(--dark); margin-bottom: 12px;
-            -webkit-appearance: none; }
-        .sheet-field:focus { border-color: var(--primary); }
-        #sheet-submit { width: 100%; padding: 16px; background: var(--primary); color: white; border: none;
-            border-radius: 14px; font-weight: 900; font-size: 1.05rem; cursor: pointer; font-family: inherit;
-            margin-bottom: 10px; -webkit-tap-highlight-color: transparent; }
-        #sheet-submit:active { background: var(--primary-light); }
-        #sheet-submit:disabled { opacity: 0.55; }
-        #sheet-error { font-size: 0.82rem; color: var(--red); text-align: center; min-height: 18px; margin-bottom: 4px; }
-        .sheet-note { font-size: 0.72rem; color: var(--muted); text-align: center; }
-        .sheet-note a { color: var(--primary); font-weight: 600; }
-        #sheet-close-btn { position: absolute; top: 16px; right: 16px; background: var(--bg); border: none;
-            width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-size: 1rem; color: var(--muted);
-            display: flex; align-items: center; justify-content: center; }
-        #signin-sheet { position: relative; }
-
         /* ── EMPTY / LOADING / TOAST ── */
         .empty { text-align: center; padding: 40px 20px; color: var(--muted); font-size: 0.9rem; }
         .empty-icon { font-size: 2.8rem; margin-bottom: 12px; }
@@ -340,25 +311,10 @@
     </div>
 </div>
 
-<!-- ── BOTTOM SHEET SIGN-IN ── -->
-<div id="sheet-overlay">
-    <div id="signin-sheet">
-        <button id="sheet-close-btn" aria-label="Close">✕</button>
-        <div class="sheet-handle"></div>
-        <div class="sheet-icon">⚽</div>
-        <div class="sheet-title">Join Watch Parties</div>
-        <div class="sheet-sub" id="sheet-sub">Sign in free — no password needed.<br>We'll remember you on this device.</div>
-        <input class="sheet-field" id="sheet-name" type="text" placeholder="Your name" autocomplete="name" inputmode="text">
-        <input class="sheet-field" id="sheet-email" type="email" placeholder="Email address" autocomplete="email" inputmode="email">
-        <div id="sheet-error"></div>
-        <button id="sheet-submit">Sign In →</button>
-        <div class="sheet-note">Free &amp; instant. No spam, ever.<br>Or <a href="/worldcup/">go back to sign in with Google</a>.</div>
-    </div>
-</div>
-
 <div id="toast"></div>
 
-<script>
+<script type="module">
+import { openSignInModal, closeSignInModal } from './signin-modal.js';
 const API = '/world_cup';
 function api(path, opts = {}) { return fetch(API + path, { credentials: 'include', ...opts }); }
 
@@ -420,7 +376,6 @@ const state = { user: null, matches: [], meetups: [], userLat: null, userLng: nu
 // ── AUTH ───────────────────────────────────────────────────────────────────
 function setUser(user) {
     state.user = user;
-    // Topbar
     const signinBtn = document.getElementById('topbar-signin-btn');
     const avPh = document.getElementById('topbar-avatar-ph');
     const av = document.getElementById('topbar-avatar');
@@ -432,13 +387,12 @@ function setUser(user) {
         if (user.avatar) { av.src = user.avatar; av.style.display = 'block'; avPh.style.display = 'none'; }
         else { avPh.textContent = (user.name || user.email || 'F')[0].toUpperCase(); avPh.style.display = 'flex'; av.style.display = 'none'; }
         document.getElementById('signin-bar').classList.remove('show');
-        closeSheet();
+        closeSignInModal();
     } else {
         signinBtn.style.display = '';
         av.style.display = 'none'; avPh.style.display = 'none'; uname.style.display = 'none';
         document.getElementById('signin-bar').classList.add('show');
     }
-    // Re-render active panel
     const activeTab = document.querySelector('.tab.active')?.dataset.panel;
     if (activeTab === 'post') renderPostPanel();
     if (activeTab === 'parties') renderParties();
@@ -447,58 +401,17 @@ function setUser(user) {
 function requireSignIn(subtitle, cb) {
     if (state.user) { cb(); return; }
     state._signInCb = cb;
-    document.getElementById('sheet-sub').textContent = subtitle || 'Sign in free — no password needed.\nWe\'ll remember you on this device.';
-    openSheet();
+    openSignInModal();
 }
 
-function openSheet() {
-    const overlay = document.getElementById('sheet-overlay');
-    overlay.style.display = 'flex';
-    requestAnimationFrame(() => overlay.classList.add('open'));
-    setTimeout(() => document.getElementById('sheet-name').focus(), 350);
-}
-function closeSheet() {
-    const overlay = document.getElementById('sheet-overlay');
-    overlay.classList.remove('open');
-    setTimeout(() => { overlay.style.display = 'none'; }, 320);
-    document.getElementById('sheet-error').textContent = '';
-    document.getElementById('sheet-name').value = '';
-    document.getElementById('sheet-email').value = '';
-}
-
-document.getElementById('sheet-close-btn').addEventListener('click', closeSheet);
-document.getElementById('sheet-overlay').addEventListener('click', e => { if (e.target === e.currentTarget) closeSheet(); });
 document.getElementById('topbar-signin-btn').addEventListener('click', () => requireSignIn(null, () => {}));
 document.getElementById('signin-bar-btn').addEventListener('click', () => requireSignIn(null, () => {}));
 
-document.getElementById('sheet-submit').addEventListener('click', async () => {
-    const name = document.getElementById('sheet-name').value.trim();
-    const email = document.getElementById('sheet-email').value.trim();
-    const errEl = document.getElementById('sheet-error');
-    errEl.textContent = '';
-    if (!email || !email.includes('@')) { errEl.textContent = 'Enter a valid email address.'; return; }
-    const btn = document.getElementById('sheet-submit');
-    btn.disabled = true; btn.textContent = 'Signing in…';
-    try {
-        const res = await api('/auth/email-login', {
-            method: 'POST', headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({ email, name: name || email.split('@')[0] }),
-        });
-        if (res.ok) {
-            const { user } = await res.json();
-            setUser(user);
-            toast(`👋 Welcome, ${user.name?.split(' ')[0] || 'fan'}!`);
-            if (state._signInCb) { const cb = state._signInCb; state._signInCb = null; setTimeout(cb, 200); }
-        } else {
-            const { error } = await res.json().catch(() => ({ error: 'Sign in failed' }));
-            errEl.textContent = error || 'Sign in failed — try again.';
-        }
-    } catch (_) { errEl.textContent = 'Network error — check your connection.'; }
-    btn.disabled = false; btn.textContent = 'Sign In →';
+document.addEventListener('wc:signin', e => {
+    setUser(e.detail);
+    toast(`👋 Welcome, ${e.detail.name?.split(' ')[0] || 'fan'}!`);
+    if (state._signInCb) { const cb = state._signInCb; state._signInCb = null; setTimeout(cb, 200); }
 });
-
-// Enter key on email field submits
-document.getElementById('sheet-email').addEventListener('keydown', e => { if (e.key === 'Enter') document.getElementById('sheet-submit').click(); });
 
 // ── TAB SWITCHING ──────────────────────────────────────────────────────────
 document.querySelectorAll('.tab').forEach(tab => {
@@ -742,7 +655,7 @@ document.querySelectorAll('.fchip').forEach(chip=>{
     renderCuratedBars(null,null);
     const[matchRes,meRes]=await Promise.all([api('/api/matches').catch(()=>null),api('/api/me').catch(()=>null)]);
     if(matchRes?.ok) state.matches=await matchRes.json();
-    if(meRes?.ok){setUser(await meRes.json());}else{setUser(null);}
+    if(meRes?.ok){setUser(await meRes.json());}else{setUser(null); openSignInModal();}
     await loadMeetups();
 })();
 </script>

--- a/worldcup/signin-modal.js
+++ b/worldcup/signin-modal.js
@@ -1,0 +1,161 @@
+// Shared sign-in modal for worldcup pages.
+// Injects the modal HTML + CSS on import, dispatches 'wc:signin' event on success.
+
+const API = '/world_cup';
+
+const SIGNIN_CSS = `
+#wc-signin-modal {
+    display: none; position: fixed; inset: 0; z-index: 500;
+    background: rgba(0,0,0,0.55); align-items: center; justify-content: center;
+}
+#wc-signin-modal.open { display: flex; }
+#wc-signin-box {
+    background: white; border-radius: 14px; padding: 32px 28px; width: 340px;
+    max-width: calc(100vw - 32px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); position: relative;
+}
+#wc-signin-box h2 { font-size: 1.2rem; font-weight: 800; color: #0a1f44; margin-bottom: 4px; }
+#wc-signin-box > p { font-size: 0.82rem; color: #6B7280; margin-bottom: 20px; }
+.wc-signin-input {
+    width: 100%; padding: 10px 12px; border: 1.5px solid #E5E7EB;
+    border-radius: 8px; font-size: 0.9rem; margin-bottom: 10px; outline: none;
+    box-sizing: border-box; font-family: inherit; color: #111827;
+}
+.wc-signin-input:focus { border-color: #0a1f44; }
+#wc-signin-submit {
+    width: 100%; padding: 11px; background: #0a1f44; color: white;
+    border: none; border-radius: 8px; font-weight: 700; font-size: 0.95rem;
+    cursor: pointer; margin-top: 4px; font-family: inherit;
+}
+#wc-signin-submit:hover { background: #1a3a6b; }
+#wc-signin-close {
+    position: absolute; top: 12px; right: 16px; background: none; border: none;
+    font-size: 1.4rem; cursor: pointer; color: #6B7280; line-height: 1;
+}
+#wc-signin-error { font-size: 0.8rem; color: #ef4444; margin-top: 6px; display: none; }
+#wc-signin-google-area { margin-bottom: 16px; }
+.wc-signin-divider {
+    display: flex; align-items: center; gap: 10px; margin: 14px 0;
+    font-size: 0.78rem; color: #6B7280;
+}
+.wc-signin-divider::before, .wc-signin-divider::after {
+    content: ''; flex: 1; height: 1px; background: #E5E7EB;
+}
+`;
+
+function injectModal() {
+    if (document.getElementById('wc-signin-modal')) return;
+
+    const style = document.createElement('style');
+    style.textContent = SIGNIN_CSS;
+    document.head.appendChild(style);
+
+    const div = document.createElement('div');
+    div.id = 'wc-signin-modal';
+    div.setAttribute('role', 'dialog');
+    div.setAttribute('aria-modal', 'true');
+    div.innerHTML = `
+        <div id="wc-signin-box">
+            <button id="wc-signin-close" aria-label="Close">×</button>
+            <h2>⚽ Join the Predictor</h2>
+            <p>Sign in to save your predictions and compete on the leaderboard.</p>
+            <div id="wc-signin-google-area"></div>
+            <input class="wc-signin-input" id="wc-signin-name" type="text" placeholder="Your name" autocomplete="name">
+            <input class="wc-signin-input" id="wc-signin-email" type="email" placeholder="Email address" autocomplete="email" inputmode="email">
+            <button id="wc-signin-submit">Sign In / Create Account</button>
+            <div id="wc-signin-error"></div>
+        </div>`;
+    document.body.appendChild(div);
+
+    div.addEventListener('click', e => { if (e.target === div) closeSignInModal(); });
+    document.getElementById('wc-signin-close').addEventListener('click', closeSignInModal);
+    document.getElementById('wc-signin-submit').addEventListener('click', handleSubmit);
+    document.getElementById('wc-signin-email').addEventListener('keydown', e => {
+        if (e.key === 'Enter') handleSubmit();
+    });
+
+    initGoogleSignIn();
+}
+
+async function handleSubmit() {
+    const name = document.getElementById('wc-signin-name').value.trim();
+    const email = document.getElementById('wc-signin-email').value.trim();
+    const errEl = document.getElementById('wc-signin-error');
+    errEl.style.display = 'none';
+    if (!email || !email.includes('@')) {
+        errEl.textContent = 'Enter a valid email address.';
+        errEl.style.display = 'block';
+        return;
+    }
+    const btn = document.getElementById('wc-signin-submit');
+    btn.disabled = true; btn.textContent = 'Signing in…';
+    try {
+        const res = await fetch(`${API}/auth/email-login`, {
+            method: 'POST', credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, name: name || email.split('@')[0] }),
+        });
+        if (res.ok) {
+            const { user } = await res.json();
+            closeSignInModal();
+            document.dispatchEvent(new CustomEvent('wc:signin', { detail: user }));
+        } else {
+            const { error } = await res.json().catch(() => ({ error: 'Login failed' }));
+            errEl.textContent = error || 'Login failed';
+            errEl.style.display = 'block';
+        }
+    } catch (_) {
+        errEl.textContent = 'Network error — try again.';
+        errEl.style.display = 'block';
+    } finally {
+        btn.disabled = false; btn.textContent = 'Sign In / Create Account';
+    }
+}
+
+async function initGoogleSignIn() {
+    try {
+        const cfg = await fetch(`${API}/api/config`, { credentials: 'include' }).then(r => r.json());
+        if (!cfg.googleClientId) return;
+        const area = document.getElementById('wc-signin-google-area');
+        if (!area) return;
+        area.innerHTML = `<div id="wc-g-btn"></div><div class="wc-signin-divider">or sign in with email</div>`;
+        const s = document.createElement('script');
+        s.src = 'https://accounts.google.com/gsi/client';
+        s.async = true;
+        s.onload = () => {
+            google.accounts.id.initialize({
+                client_id: cfg.googleClientId,
+                callback: async ({ credential }) => {
+                    try {
+                        const r = await fetch(`${API}/auth/verify`, {
+                            method: 'POST', credentials: 'include',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ token: credential }),
+                        });
+                        if (r.ok) {
+                            const meRes = await fetch(`${API}/api/me`, { credentials: 'include' });
+                            if (meRes.ok) {
+                                const user = await meRes.json();
+                                closeSignInModal();
+                                document.dispatchEvent(new CustomEvent('wc:signin', { detail: user }));
+                            }
+                        }
+                    } catch (_) {}
+                },
+            });
+            google.accounts.id.renderButton(document.getElementById('wc-g-btn'), {
+                theme: 'outline', size: 'large', text: 'signin_with', width: 284,
+            });
+        };
+        document.head.appendChild(s);
+    } catch (_) {}
+}
+
+injectModal();
+
+export function openSignInModal() {
+    document.getElementById('wc-signin-modal')?.classList.add('open');
+}
+
+export function closeSignInModal() {
+    document.getElementById('wc-signin-modal')?.classList.remove('open');
+}


### PR DESCRIPTION
- New signin-modal.js: shared ES module that injects the existing login
  dialog (email + Google OAuth) into any page and dispatches wc:signin
  on success
- index.html: auto-opens the signin modal after session check fails
- match.html: imports shared module, opens modal if no session, listens
  for wc:signin to update state and re-render meetup/chat panels
- meetup.html: replaces custom bottom-sheet sign-in with the shared modal;
  requireSignIn() now opens the modal instead; auto-opens on page load
  when not authenticated

https://claude.ai/code/session_01At2CfHG7L2DKyuQcgQXLTa